### PR TITLE
[BUGFIX]: annotation overlap text (fixes issue #3)

### DIFF
--- a/app/assets/javascripts/backbone/models/text.js.coffee
+++ b/app/assets/javascripts/backbone/models/text.js.coffee
@@ -31,10 +31,11 @@ class Didh.Models.Text extends Backbone.Model
   getIndexedSentencesCount: () ->
     count = @get('keywords_grouped').length
 
-  getAnnotationCount: () ->
-    count = _.reduce(@get('sentences'), (memo, num) ->
-      memo + parseInt num.count
-    , 0)
+  # unused
+  # getAnnotationCount: () ->
+  #   count = _.reduce(@get('sentences'), (memo, num) ->
+  #     memo + parseInt num.count
+  #   , 0)
 
   getTotalMarkedAndIndexed: () ->
     all = @get('sentences').concat(@get('keywords_grouped'))

--- a/app/assets/javascripts/backbone/views/frontend/text_view.js.coffee
+++ b/app/assets/javascripts/backbone/views/frontend/text_view.js.coffee
@@ -75,7 +75,8 @@ class Didh.Views.Frontend.TextView extends Backbone.View
         minWidth = 1
         width = sentence.count * 1
 
-      count = @model.getAnnotationCountFor( sentence.sentence)
+      # unused
+      # count = @model.getAnnotationCountFor( sentence.sentence)
       annotation = $('<span data-sentence="' + sentence.sentence + '" style="display: none; width: ' + minWidth + 'px; height: ' + height + 'px;" class="annotation"></span>')
 
       $el.before(annotation)

--- a/app/assets/javascripts/backbone/views/frontend/text_view.js.coffee
+++ b/app/assets/javascripts/backbone/views/frontend/text_view.js.coffee
@@ -68,12 +68,12 @@ class Didh.Views.Frontend.TextView extends Backbone.View
       height = $el.height()
 
       if @visualization == 'opacity'
-        opacity = sentence.count / 20
+        opacity = sentence.count / sentence.annotations_max_n
         minWidth = 10
         width = 10
       else
         minWidth = 1
-        width = sentence.count * 1
+        width = sentence.count / sentence.annotations_max_n * 100
 
       # unused
       # count = @model.getAnnotationCountFor( sentence.sentence)

--- a/app/models/annotation.rb
+++ b/app/models/annotation.rb
@@ -6,6 +6,10 @@ class Annotation < ActiveRecord::Base
     self.group(:sentence).select("sentence, COUNT(*) as count")
   end
 
+  def self.all_grouped_max_n
+    self.group(:sentence).select("sentence, COUNT(*) as count").order(count: :desc).limit(1)
+  end
+
   def as_json(options = {})
     h = super(options)
     h[:sentence_body] = sentence_model.body

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -40,6 +40,7 @@ class Text < ActiveRecord::Base
 				:edition => edition.label,
 				:keywords_grouped => keywords.all_grouped,
 				:sentences => annotations.all_grouped
+                                :annotations_max_n => annotations.all_grouped_max_n
 			}
 		end
 	end


### PR DESCRIPTION
## Description

The online version of the book has many interactive features, one of which is an annotation bar to the left of the text which is essentially a vertical histogram of the number of annotations for a particular sentence. In the introduction to the book, [_The Digital Humanities Moment_ by Matthew K. Gold](http://dhdebates.gc.cuny.edu/debates/text/2), the annotation bar overlaps the text in several places. This was noted in issue #3 reported more than a year ago.
## Analysis

The position of the `<span/>` comprising the annotation bar is hardcoded as `-100px` in the CSS:

```
.annotation{
    display:    block;
    width:      5px;
    height:     10px;
    background: #02adef;
    position:   absolute;
    left:       -100px;
    overflow:   visible;
}
```

This is the source of the bug.

The JS app sets the width of each span to illustrate the number of annotations. Gold's essay, being the first, has been heavily annotated with some sentences garnering more than 100 annotations. There is no limit set for the width, however, so when the comment count is (> 100), the annotation will begin to overlap the text.
## Solution

This fix adds a new property (`annotations_max_n`) to the Text::as_json method which is simply the highest number of annotations for a sentence in that text. The value of this property is then used to scale the annotation bar between 1 and 100px, as set in the CSS, and is also used to scale the opacity between 0 and 1. Currently, there is no upper bound for the opacity. Although values outside the 0 to 1 range are not errors, they have no additional effect, either.
## Misc

Two important notes regarding this pull request. 
1. I do not have access to a working instance, so this is not tested. I believe it should work, though.
2. I commented out a method and a single line of code, both of which appear to be unused in any way. As I can not test the changes, I have left them commented out with a note that they appear unused.
